### PR TITLE
add the full command names completions & their sub-completions

### DIFF
--- a/src/_wtwitch
+++ b/src/_wtwitch
@@ -17,22 +17,22 @@ subs=(
 case $state in
   (cmds)
     local -a commands; commands=(
-      'w:watch [name] streamer'
-      's:subscribe to [name] streamer'
-      'u:unsubscribe from [name] streamer'
-      'c:view your settings and the status of streamers you are subscribed to'
+      {w,watch}':watch [name] streamer'
+      {s,subscribe}':subscribe to [name] streamer'
+      {u,unsub}':unsubscribe from [name] streamer'
+      {c,check}':view your settings and the status of streamers you are subscribed to'
       'e:search games/categories for [search-term]'
       'n:search streamers/channels for [search-term]'
-      'g:view the top streamers for [name] game/category'
-      't:view the top games and streamers on Twitch'
-      'v:list [name]s VODs'
+      {g,game}':view the top streamers for [name] game/category'
+      {t,top}':view the top games and streamers on Twitch'
+      {v,vod}':list [name]s VODs'
       'f:toggle the printing of offline subs with [c]heck'
       'l:toggle the usage of colors in wtwitch output'
-      'p:change the player program that gets passed to streamlink'
-      'q:change the video quality that gets passed to streamlink'
-      'b:block [name] streamer(s), preventing them from appearing in any output'
+      {p,player}':change the player program that gets passed to streamlink'
+      {q,quality}':change the video quality that gets passed to streamlink'
+      {b,block}':block [name] streamer(s), preventing them from appearing in any output'
       'version:print the current version of wtwitch'
-      'h:print this help'
+      {h,help}':print this help'
     )
 
     _describe cmd commands && ret=0

--- a/src/_wtwitch
+++ b/src/_wtwitch
@@ -39,17 +39,17 @@ case $state in
     ;;
   (names)
     case $line[1] in
-      w)
+      w|watch)
         wtwitch _completion_cache_online_subscription_json &> /dev/null
         local online_subs_file; online_subs_file="${XDG_CACHE_DIR:-${HOME}/.cache}/wtwitch/online-subs"
         local -a streamers; streamers=("${(fL)$(<$online_subs_file)}")
 
         _describe online streamers && ret=0
         ;;
-      u|v)
+      u|unsub|v|vod)
         _describe sublist subs && ret=0
         ;;
-      q)
+      q|quality)
         local -a qualities=(
           'audio_only'
           'worst'
@@ -68,7 +68,7 @@ case $state in
     ;;
   (multiple)
     case $line[1] in
-      u)
+      u|unsub)
         _describe sublist subs && ret=0
         ;;
     esac


### PR DESCRIPTION
Adding to #9
I find it easier to read & filter full command names than just the mnemonics/descriptions.