### PR TITLE
pass the proper channel name to watch_stream

### DIFF
--- a/src/wtwitch
+++ b/src/wtwitch
@@ -954,7 +954,7 @@ open_selected_stream()
     exit_script_on_failure "$(get_translation install_fzf_first)"
   fi
 
-  stream="$(check_twitch_streams --online-only | fzf --ansi | cut -d: -f1 | sed 's/ *//')"
+  stream="$(check_twitch_streams --online-only | fzf --ansi | sed 's/^ *\|[:(].*//g')"
 
   if [ -n "$stream" ]; then
     watch_stream "$stream"


### PR DESCRIPTION
Resolves #27

This change assigns the proper channel name to be passed to watch_stream() by removing any localized name and brackets. Additionally, condensing the character removal done by `cut` with `sed`.