### PR TITLE
Handle null game_id by defaulting to "No Category"

### DIFF
--- a/src/wtwitch
+++ b/src/wtwitch
@@ -470,6 +470,12 @@ TRANSLATIONS="$(cat <<EOF
     "de": "You need to install fzf to use this feature.",
     "es": "You need to install fzf to use this feature.",
     "fr": "You need to install fzf to use this feature."
+  },
+  "no_category": {
+    "en": "No Category",
+    "de": "Keine Kategorie",
+    "es": "Sin categoría",
+    "fr": "Pas de catégorie"
   }
 }
 EOF
@@ -574,7 +580,7 @@ get_game_name()
 {
   # Default to "No Category" if game_id is missing
   if [[ -z "$1" ]]; then
-    printf "No Category"
+    get_translation "no_category"
     return
   fi
 

--- a/src/wtwitch
+++ b/src/wtwitch
@@ -572,6 +572,12 @@ exit_script_on_failure()
 #######################################
 get_game_name()
 {
+  # Default to "No Category" if game_id is missing
+  if [[ -z "$1" ]]; then
+    printf "No Category"
+    return
+  fi
+
   # Add "id" prefix as jq does not accept numerical identifiers
   local -r gameID="id$1"
 
@@ -1151,13 +1157,14 @@ check_twitch_streams_helper()
 
   # Get stream game name from game ID
   local streamGame
-  streamGame="$(get_game_name "${streamerData[0]}")"
+  streamGame="$(get_game_name "${streamerData[0]:-}")"
 
   # Get streamer-set stream name
   # Truncate stream name if necessary; some streamers have stream titles longer
   # than the terminal width and cause ugly output
   local -r maxTitleLength="$(( TERMINAL_WIDTH - TITLE_CHARACTERS - ${#streamGame} - ${#2} - 2 ))"
-  local streamName="${streamerData[1]:0:${maxTitleLength}}"
+  local streamName="${streamerData[1]:-}"
+  streamName="${streamName:0:${maxTitleLength}}"
 
   if [[ "${#streamName}" == "${maxTitleLength}" ]]; then
     streamName+="…"


### PR DESCRIPTION
Fixes https://github.com/krathalan/wtwitch/issues/37 by adding a safety check in `get_game_name()` to detect when game_id is empty (missing data) and return "No Category" instead of making an invalid API call. Additionally, updated `check_twitch_streams_helper()` to use safe parameter expansion (`${variable:-}`) so unset array elements gracefully return empty strings rather than causing "unbound variable" errors. These minimal changes allow streamers without categories to display properly as (No Category) while preventing the false rate-limit error.